### PR TITLE
Implement SpakSpecsBuilder via DIBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # spak-di
-spåK di :: Single Page Application Kit - Dependency Injection ::
+DI for spåK :: Dependency Injection for Single Page Application Kit ::
+
+Implements the `SpakSpecsBuilder` with `DIBuilder`.
+
+The `DIBuilder` uses `wirejs` under the hood providing an implementation that allows components to register via spec objects with the DI system.
+
+Once the `SpakBootstrapper` has asked all components to register it will ask `DIBuilder` to `build` an IocContainer object.
+
+[See our docs](./doc/index.md) for how to register your components.

--- a/index.js
+++ b/index.js
@@ -9,10 +9,11 @@ import ActionSpec from "./lib/ActionSpec";
 import HooksSpec from "./lib/HooksSpec";
 import RegistrySpec from "./lib/RegistrySpec";
 import SpecRef from "./lib/SpecRef";
+import DIBuilder from "./lib/DIBuilder";
 
 var SpecGroup = SpecRegistration; // Alias for semantics.
 
 export { SpecRegistry, SpecRegistration, SpecGroup, CondSpecs, SpecRef,
          SpecFromFn, SpecFromClass, SpecFromValue,
          ConfigMod, SpecWithConfigMod,
-         ActionSpec, HooksSpec, RegistrySpec };
+         ActionSpec, HooksSpec, RegistrySpec, DIBuilder };

--- a/lib/DIBuilder.js
+++ b/lib/DIBuilder.js
@@ -1,0 +1,23 @@
+/*jshint newcap: false */
+import Q from "q";
+import wire from "wire";
+import wirePlugin from "./wirePlugin";
+
+export default class DIBuilder {
+    build(specs) {
+        return Q(wire(
+            specs.all().reduce(this._writeToCfg, this._cfgSeed())
+        ));
+    }
+
+    _writeToCfg(cfg, registration) {
+        registration.writeTo(cfg);
+        return cfg;
+    }
+
+    _cfgSeed() {
+        return {
+            $plugins: [wirePlugin]
+        };
+    }
+}


### PR DESCRIPTION
We can use DIBuilder to have a fully functional DI system (via wirejs) w/ spak.

Just tell specs to use this builder.

`specs.useBuilder(new DIBuilder())`
